### PR TITLE
Have RegionEnterLeaveEvent Extend PlayerEvent Instead of Event

### DIFF
--- a/src/main/java/org/skriptlang/skriptworldguard/worldguard/RegionEnterLeaveEvent.java
+++ b/src/main/java/org/skriptlang/skriptworldguard/worldguard/RegionEnterLeaveEvent.java
@@ -3,28 +3,23 @@ package org.skriptlang.skriptworldguard.worldguard;
 import com.sk89q.worldguard.session.MoveType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
-import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
 
-public class RegionEnterLeaveEvent extends Event implements Cancellable {
+public class RegionEnterLeaveEvent extends PlayerEvent implements Cancellable {
 
 	private final static HandlerList handlers = new HandlerList();
 	private boolean cancelled = false;
 
-	private final Player player;
 	private final WorldGuardRegion region;
 	private final MoveType moveType;
 	private final boolean enter;
 
 	public RegionEnterLeaveEvent(Player player, WorldGuardRegion region, MoveType moveType, boolean enter) {
-		this.player = player;
+		super(player);
 		this.region = region;
 		this.moveType = moveType;
 		this.enter = enter;
-	}
-
-	public Player getPlayer() {
-		return player;
 	}
 
 	public WorldGuardRegion getRegion() {


### PR DESCRIPTION
This PR simply fix RegionEnterLeaveEvent where it was previously extended from `Event` with `player` parameter instead of extending from `PlayerEvent`.