### PR TITLE
Switch to 2.10+, Java 17, and Spigot 1.19.4+

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,16 +6,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v2
+      - uses: actions/checkout@v4
+      - name: Set up JDK 1.17
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: '8'
+          java-version: '17'
       - name: Build with Gradle
         run: ./gradlew nightlyBuild
       - name: Upload Nightly Build
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: success()
         with:
           name: skript-worldguard-nightly

--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ Report it at https://github.com/SkriptLang/skript-worldguard/issues.
 Tutorials are available on the wiki at https://github.com/SkriptLang/skript-worldguard/wiki.
 
 ## Requirements
-skript-worldguard is designed for Skript 2.6.3 and above.
-It works with all Minecraft versions supported by Skript 2.6.3.
+skript-worldguard is designed for Skript 2.10.0 and above.
+It works with all Minecraft versions supported by Skript 2.10.0.

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ compileJava.options.encoding = 'UTF-8'
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 
@@ -25,14 +25,13 @@ repositories {
 
 dependencies {
     // eclipse annotations are only present for IDE analysis, they should not be used
-    implementation group: 'org.eclipse.jdt', name: 'org.eclipse.jdt.annotation', version: '2.2.600'
     implementation group: 'org.jetbrains', name: 'annotations', version: '24.1.0'
 
-    implementation group: 'org.spigotmc', name: 'spigot-api', version: '1.13.2-R0.1-SNAPSHOT'
-    implementation (group: 'com.github.SkriptLang', name: 'Skript', version: '2.7.3') {
+    implementation group: 'org.spigotmc', name: 'spigot-api', version: '1.19.4-R0.1-SNAPSHOT'
+    implementation (group: 'com.github.SkriptLang', name: 'Skript', version: '2.11.0') {
         transitive = false
     }
-    implementation (group: 'com.sk89q.worldguard', name: 'worldguard-bukkit', version: '7.0.0') {
+    implementation (group: 'com.sk89q.worldguard', name: 'worldguard-bukkit', version: '7.0.8') {
         exclude module: 'bstats-bukkit'
     }
 }

--- a/src/main/java/org/skriptlang/skriptworldguard/RegionClasses.java
+++ b/src/main/java/org/skriptlang/skriptworldguard/RegionClasses.java
@@ -31,7 +31,7 @@ public class RegionClasses {
 				.examples("region \"region\" in world(\"world\"")
 				.requiredPlugins("WorldGuard 7")
 				.since("1.0")
-				.parser(new Parser<WorldGuardRegion>() {
+				.parser(new Parser<>() {
 					// TODO maybe we should do something else here... perhaps make use of SkriptParser methods?
 					final Pattern regionPattern = Pattern.compile(
 							"(?:the )?(?:worldguard )?region (?:with (?:the )?(?:name|id) |named )?\"(.+)\" (?:in|of) (?:(?:the )?world )?\"(.+)\""
@@ -115,7 +115,7 @@ public class RegionClasses {
 				.examples("on region enter:",
 						"\tsend \"The move type is %the move type%\"")
 				.since("1.0")
-				.parser(new Parser<MoveType>() {
+				.parser(new Parser<>() {
 					@Override
 					@Nullable
 					public MoveType parse(@NotNull String input, @NotNull ParseContext context) {

--- a/src/main/java/org/skriptlang/skriptworldguard/SkriptWorldGuard.java
+++ b/src/main/java/org/skriptlang/skriptworldguard/SkriptWorldGuard.java
@@ -28,8 +28,8 @@ public class SkriptWorldGuard extends JavaPlugin {
 			getLogger().severe("Could not find Skript! Make sure you have it installed and that it properly loaded. Disabling...");
 			getServer().getPluginManager().disablePlugin(this);
 			return;
-		} else if (Skript.getVersion().isSmallerThan(new Version(2, 6, 3))) {
-			getLogger().severe("You are running an unsupported version of Skript. Please update to at least Skript 2.6.3. Disabling...");
+		} else if (Skript.getVersion().isSmallerThan(new Version(2, 10, 0))) {
+			getLogger().severe("You are running an unsupported version of Skript. Please update to at least Skript 2.10.0. Disabling...");
 			getServer().getPluginManager().disablePlugin(this);
 			return;
 		}

--- a/src/main/java/org/skriptlang/skriptworldguard/elements/events/EvtRegionEnterLeave.java
+++ b/src/main/java/org/skriptlang/skriptworldguard/elements/events/EvtRegionEnterLeave.java
@@ -5,14 +5,13 @@ import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.registrations.EventValues;
-import ch.njol.skript.util.Getter;
 import com.sk89q.worldguard.session.MoveType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skriptworldguard.worldguard.RegionEnterLeaveEvent;
 import org.skriptlang.skriptworldguard.worldguard.WorldGuardRegion;
-import org.bukkit.entity.Player;
-import org.bukkit.event.Event;
 
 public class EvtRegionEnterLeave extends SkriptEvent {
 
@@ -27,24 +26,12 @@ public class EvtRegionEnterLeave extends SkriptEvent {
 						"\tsend \"You entered %region%\"")
 				.requiredPlugins("WorldGuard 7")
 				.since("1.0");
-		EventValues.registerEventValue(RegionEnterLeaveEvent.class, WorldGuardRegion.class, new Getter<WorldGuardRegion, RegionEnterLeaveEvent>() {
-			@Override
-			public WorldGuardRegion get(RegionEnterLeaveEvent event) {
-				return event.getRegion();
-			}
-		}, EventValues.TIME_NOW);
-		EventValues.registerEventValue(RegionEnterLeaveEvent.class, Player.class, new Getter<Player, RegionEnterLeaveEvent>() {
-			@Override
-			public Player get(RegionEnterLeaveEvent event) {
-				return event.getPlayer();
-			}
-		}, EventValues.TIME_NOW);
-		EventValues.registerEventValue(RegionEnterLeaveEvent.class, MoveType.class, new Getter<MoveType, RegionEnterLeaveEvent>() {
-			@Override
-			public MoveType get(RegionEnterLeaveEvent e) {
-				return e.getMoveType();
-			}
-		}, EventValues.TIME_NOW);
+		EventValues.registerEventValue(RegionEnterLeaveEvent.class, WorldGuardRegion.class,
+					RegionEnterLeaveEvent::getRegion, EventValues.TIME_NOW);
+		EventValues.registerEventValue(RegionEnterLeaveEvent.class, Player.class,
+				RegionEnterLeaveEvent::getPlayer, EventValues.TIME_NOW);
+		EventValues.registerEventValue(RegionEnterLeaveEvent.class, MoveType.class,
+				RegionEnterLeaveEvent::getMoveType, EventValues.TIME_NOW);
 	}
 
 	private @Nullable Literal<WorldGuardRegion> regions;
@@ -59,14 +46,15 @@ public class EvtRegionEnterLeave extends SkriptEvent {
 	}
 
 	@Override
-	public boolean check(@NotNull Event e) {
-		RegionEnterLeaveEvent event = (RegionEnterLeaveEvent) e;
-		if (event.isEntering() != enter) { // This is a region enter event, but we want a region leave event
+	public boolean check(@NotNull Event event) {
+		if (!(event instanceof RegionEnterLeaveEvent enterLeaveEvent))
+			return false;
+		if (enterLeaveEvent.isEntering() != enter) { // This is a region enter event, but we want a region leave event
 			return false;
 		} else if (regions == null) { // There are no regions to check so it is valid
 			return true;
 		}
-		return regions.check(event, region -> region.equals(event.getRegion()));
+		return regions.check(enterLeaveEvent, region -> region.equals(enterLeaveEvent.getRegion()));
 	}
 
 	@Override


### PR DESCRIPTION
Bumps dependencies to 2.10.0 minimum, which allows java 17, spigot 1.19.4+, and worldguard 7.0.8+. Updates event-values.