### PR TITLE
Allow some worlds to be filled in automatically in syntax

### DIFF
--- a/src/main/java/org/skriptlang/skriptworldguard/elements/effects/EffCreateRegion.java
+++ b/src/main/java/org/skriptlang/skriptworldguard/elements/effects/EffCreateRegion.java
@@ -50,7 +50,7 @@ public class EffCreateRegion extends Effect {
 
 	static {
 		Skript.registerEffect(EffCreateRegion.class,
-				"create [a] [:temporary] global [worldguard] region [named] %string% in %world%",
+				"create [a] [:temporary] global [worldguard] region [named] %string% [in %world%]",
 				"create [a] [:temporary] [cuboid|rectangular] [worldguard] region [named] %string% [in %-world%] (between|from) %location% (to|and) %location%",
 				"create [a] [:temporary] polygonal [worldguard] region [named] %string% [in %-world%] with [a] min[imum] height of %number% and [a] max[imum] height of %number% with [the] points %locations%"
 		);

--- a/src/main/java/org/skriptlang/skriptworldguard/elements/expressions/ExprRegionNamed.java
+++ b/src/main/java/org/skriptlang/skriptworldguard/elements/expressions/ExprRegionNamed.java
@@ -27,8 +27,9 @@ public class ExprRegionNamed extends SimpleExpression<WorldGuardRegion> {
 
 	static {
 		Skript.registerExpression(ExprRegionNamed.class, WorldGuardRegion.class, ExpressionType.COMBINED,
-				"[the] [worldguard] region[s] [with [the] (name[s]|id[s])|named] %strings% (in|of) [[the] world] %world%",
-				"[the] [worldguard] region[s] [with [the] (name[s]|id[s])|named] %strings% [%world%]"
+				"[the] [worldguard] region[s] [named] %strings% [(in|of) [[the] world] %world%]",
+				"[the] [worldguard] region[s] with [the] (name[s]|id[s]) %strings% [(in|of) [[the] world] %world%]"
+
 		);
 	}
 

--- a/src/main/java/org/skriptlang/skriptworldguard/elements/expressions/ExprRegionNamed.java
+++ b/src/main/java/org/skriptlang/skriptworldguard/elements/expressions/ExprRegionNamed.java
@@ -27,7 +27,8 @@ public class ExprRegionNamed extends SimpleExpression<WorldGuardRegion> {
 
 	static {
 		Skript.registerExpression(ExprRegionNamed.class, WorldGuardRegion.class, ExpressionType.COMBINED,
-				"[the] [worldguard] region[s] [with [the] (name[s]|id[s])|named] %strings% (in|of) [[the] world] %world%"
+				"[the] [worldguard] region[s] [with [the] (name[s]|id[s])|named] %strings% (in|of) [[the] world] %world%",
+				"[the] [worldguard] region[s] [with [the] (name[s]|id[s])|named] %strings% [%world%]"
 		);
 	}
 


### PR DESCRIPTION
Changes some `in %world%` syntaxes to be optional, allowing default values to be supplied if omitted.
ExprRegionNamed was split into two patterns to reduce complexity,