### PR TITLE
Update for supported 26.2 Minecraft 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
 
       - name: Grant execute permission for gradlew

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build skript-worldguard
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build --no-daemon
+
+      - name: Upload built jar
+        uses: actions/upload-artifact@v4
+        with:
+          name: skript-worldguard-jar
+          path: build/libs/*.jar
+          

--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ Tutorials are available on the wiki at https://github.com/SkriptLang/skript-worl
 ## Requirements
 skript-worldguard is designed for Skript 2.14.0 and newer.
 It works with all Minecraft versions supported by Skript 2.14.0.
+
+## Credits 
+
+### Maintainer
+- Sahur01-arch

--- a/README.md
+++ b/README.md
@@ -12,3 +12,14 @@ Tutorials are available on the wiki at https://github.com/SkriptLang/skript-worl
 skript-worldguard is designed for Skript 2.14.0 and newer.
 It works with all Minecraft versions supported by Skript 2.14.0.
 
+## Fork Information
+
+This project is a fork of Skript-WorldGuard by SkriptLang.
+
+Original:
+https://github.com/SkriptLang/skript-worldguard
+
+Fork maintained by:
+Sahur01-arch
+
+Changes in this fork are maintained independently.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,3 @@ Tutorials are available on the wiki at https://github.com/SkriptLang/skript-worl
 skript-worldguard is designed for Skript 2.14.0 and newer.
 It works with all Minecraft versions supported by Skript 2.14.0.
 
-## Credits 
-
-### Maintainer
-- Sahur01-arch

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ compileJava.options.encoding = 'UTF-8'
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(25))
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,28 +17,52 @@ java {
 
 repositories {
     mavenCentral()
-    maven { url 'https://repo.skriptlang.org/releases' }
-    maven { url 'https://repo.purpurmc.org/snapshots' }
-    maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
-    maven { url "https://maven.enginehub.org/repo/" }
+
+    maven {
+        url 'https://repo.skriptlang.org/releases'
+    }
+
+    maven {
+        url 'https://repo.purpurmc.org/snapshots'
+    }
+
+    maven {
+        url 'https://oss.sonatype.org/content/repositories/snapshots'
+    }
+
+    maven {
+        url 'https://maven.enginehub.org/repo/'
+    }
 }
 
 dependencies {
-    // eclipse annotations are only present for IDE analysis, they should not be used
-    implementation group: 'org.jetbrains', name: 'annotations', version: '24.1.0'
+    // Eclipse/IDE annotations only.
+    // Not bundled into the addon JAR.
+    compileOnly group: 'org.jetbrains', name: 'annotations', version: '24.1.0'
 
-    // Target Purpur/Paper API 26.2 (menggantikan spigot-api 1.19.4 lama)
-    implementation group: 'org.purpurmc.purpur', name: 'purpur-api', version: '26.2.build.+'
+    // Target Purpur/Paper API 26.2.
+    // Provided by the Minecraft server.
+    compileOnly group: 'org.purpurmc.purpur', name: 'purpur-api', version: '26.2.build.2620-stable'
 
-    // Skript versi yang sudah support Paper/Purpur 26.2 (lihat changelog Skript 2.16.0)
-    implementation (group: 'com.github.SkriptLang', name: 'Skript', version: '2.16.0') {
+    // Skript API.
+    // Provided by the server.
+    compileOnly(group: 'com.github.SkriptLang', name: 'Skript', version: '2.16.0') {
         transitive = false
     }
 
-    // WorldGuard versi terbaru yang stabil
-    implementation (group: 'com.sk89q.worldguard', name: 'worldguard-bukkit', version: '7.0.12') {
+    // WorldGuard API.
+    // Provided by the server.
+    compileOnly(group: 'com.sk89q.worldguard', name: 'worldguard-bukkit', version: '7.0.18') {
         exclude module: 'bstats-bukkit'
     }
+}
+
+configurations.configureEach {
+    resolutionStrategy.force(
+        'com.google.guava:guava:33.6.0-jre',
+        'com.google.code.gson:gson:2.14.0',
+        'it.unimi.dsi:fastutil:8.5.18'
+    )
 }
 
 processResources {
@@ -50,15 +74,21 @@ processResources {
 tasks.register('nightlyResources', ProcessResources) {
     from 'src/main/resources', {
         include '**'
+
         filter ReplaceTokens, tokens: [
-                'version': project.property('version') + '-nightly-' + 'git rev-parse --short HEAD'.execute().text.trim()
+            'version': project.property('version') +
+                    '-nightly-' +
+                    'git rev-parse --short HEAD'.execute().text.trim()
         ]
     }
+
     into 'build/resources/main'
 }
 
 tasks.register('nightlyBuild', Jar) {
     dependsOn nightlyResources
+
     from sourceSets.main.output
+
     archiveFileName = 'skript-worldguard-nightly.jar'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'org.skriptlang.skript'
-version '1.0.1'
+version '1.0.2'
 
 compileJava.options.encoding = 'UTF-8'
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
     }
 
     maven {
-        url 'https://repo.purpurmc.org/snapshots'
+        url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots'
     }
 
     maven {
@@ -42,7 +42,7 @@ dependencies {
 
     // Target Purpur/Paper API 26.2.
     // Provided by the Minecraft server.
-    compileOnly group: 'org.purpurmc.purpur', name: 'purpur-api', version: '26.2.build.2620-stable'
+    compileOnly group: 'org.spigotmc', name: 'spigot-api', version: '26.2-R0.1-SNAPSHOT'
 
     // Skript API.
     // Provided by the server.

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ compileJava.options.encoding = 'UTF-8'
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(25))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ java {
 repositories {
     mavenCentral()
     maven { url 'https://repo.skriptlang.org/releases' }
-    maven { url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots' }
+    maven { url 'https://repo.purpurmc.org/snapshots' }
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     maven { url "https://maven.enginehub.org/repo/" }
 }
@@ -27,11 +27,16 @@ dependencies {
     // eclipse annotations are only present for IDE analysis, they should not be used
     implementation group: 'org.jetbrains', name: 'annotations', version: '24.1.0'
 
-    implementation group: 'org.spigotmc', name: 'spigot-api', version: '1.19.4-R0.1-SNAPSHOT'
-    implementation (group: 'com.github.SkriptLang', name: 'Skript', version: '2.14.0-pre1') {
+    // Target Purpur/Paper API 26.2 (menggantikan spigot-api 1.19.4 lama)
+    implementation group: 'org.purpurmc.purpur', name: 'purpur-api', version: '26.2.build.+'
+
+    // Skript versi yang sudah support Paper/Purpur 26.2 (lihat changelog Skript 2.16.0)
+    implementation (group: 'com.github.SkriptLang', name: 'Skript', version: '2.16.0') {
         transitive = false
     }
-    implementation (group: 'com.sk89q.worldguard', name: 'worldguard-bukkit', version: '7.0.8') {
+
+    // WorldGuard versi terbaru yang stabil
+    implementation (group: 'com.sk89q.worldguard', name: 'worldguard-bukkit', version: '7.0.12') {
         exclude module: 'bstats-bukkit'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/org/skriptlang/skriptworldguard/SkriptWorldGuard.java
+++ b/src/main/java/org/skriptlang/skriptworldguard/SkriptWorldGuard.java
@@ -41,6 +41,11 @@ import java.lang.reflect.InvocationTargetException;
 
 public class SkriptWorldGuard extends JavaPlugin implements AddonModule {
 
+  @Override
+  public String name() {
+    return "skript-worldguard";
+  }
+
 	private static SkriptWorldGuard instance;
 
 	public static SkriptWorldGuard getInstance() {

--- a/src/main/java/org/skriptlang/skriptworldguard/elements/expressions/ExprRegionPoints.java
+++ b/src/main/java/org/skriptlang/skriptworldguard/elements/expressions/ExprRegionPoints.java
@@ -60,7 +60,7 @@ public class ExprRegionPoints extends PropertyExpression<WorldGuardRegion, Locat
 		List<Location> locations = new ArrayList<>();
 		if (isAll) {
 			for (WorldGuardRegion region : regions) {
-				int minY = region.region().getMinimumPoint().getY();
+				int minY = region.region().getMinimumPoint().y();
 				region.region().getPoints().stream()
 						.map(point -> BukkitAdapter.adapt(region.world(), point.toBlockVector3(minY)))
 						.forEach(locations::add);

--- a/src/main/java/org/skriptlang/skriptworldguard/worldguard/RegionUtils.java
+++ b/src/main/java/org/skriptlang/skriptworldguard/worldguard/RegionUtils.java
@@ -60,7 +60,7 @@ public final class RegionUtils {
 	 * A utility method for obtaining all of the regions in a world.
 	 * @param world The world to obtain regions of.
 	 * @return The regions of {@code world}.
-	 *  If {@link #getRegionManager(World)} is unavailable, this method returns an empty list.
+	 * If {@link #getRegionManager(World)} is unavailable, this method returns an empty list.
 	 */
 	public static @Unmodifiable List<WorldGuardRegion> getRegions(World world) {
 		RegionManager regionManager = getRegionManager(world);
@@ -115,9 +115,11 @@ public final class RegionUtils {
 		}
 
 		List<WorldGuardRegion> regions = new ArrayList<>();
-		for (ProtectedRegion region : regionManager.getApplicableRegions(BukkitAdapter.asBlockVector(location))) {
+		for (ProtectedRegion region : regionManager.getApplicableRegions(
+				BukkitAdapter.asBlockVector(location))) {
 			regions.add(new WorldGuardRegion(world, region));
 		}
+
 		return regions;
 	}
 
@@ -132,9 +134,16 @@ public final class RegionUtils {
 		if (world == null) {
 			return false;
 		}
+
 		LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
-		return WorldGuard.getInstance().getPlatform().getSessionManager().hasBypass(localPlayer, BukkitAdapter.adapt(world)) ||
-				getRegionContainer().createQuery().testBuild(BukkitAdapter.adapt(location), localPlayer);
+
+		return WorldGuard.getInstance()
+				.getPlatform()
+				.getSessionManager()
+				.hasBypass(localPlayer, BukkitAdapter.adapt(world))
+				|| getRegionContainer()
+				.createQuery()
+				.testBuild(BukkitAdapter.adapt(location), localPlayer);
 	}
 
 	/**
@@ -145,16 +154,25 @@ public final class RegionUtils {
 	 */
 	public static boolean canBuild(Player player, WorldGuardRegion... regions) {
 		LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
+
 		// check bypass
 		for (WorldGuardRegion region : regions) {
-			if (WorldGuard.getInstance().getPlatform().getSessionManager().hasBypass(localPlayer, BukkitAdapter.adapt(region.world()))) {
+			if (WorldGuard.getInstance()
+					.getPlatform()
+					.getSessionManager()
+					.hasBypass(localPlayer, BukkitAdapter.adapt(region.world()))) {
 				return true;
 			}
 		}
+
 		// create queryable set of regions
-		ApplicableRegionSet regionSet = new RegionResultSet((List<ProtectedRegion>) Arrays.stream(regions)
-				.map(WorldGuardRegion::region)
-				.collect(Collectors.toCollection(ArrayList::new)), null);
+		ApplicableRegionSet regionSet = new RegionResultSet(
+				(List<ProtectedRegion>) Arrays.stream(regions)
+						.map(WorldGuardRegion::region)
+						.collect(Collectors.toCollection(ArrayList::new)),
+				null
+		);
+
 		return regionSet.testState(localPlayer, Flags.BUILD);
 	}
 
@@ -163,21 +181,33 @@ public final class RegionUtils {
 	 * @param regionIterator An iterator over the regions whose blocks should be iterated over.
 	 * @return An iterator over the blocks of the regions of {@code regionsIterator}.
 	 */
-	public static Iterator<Block> getRegionBlockIterator(Iterator<WorldGuardRegion> regionIterator) {
-		if (!regionIterator.hasNext()) { // no blocks to iterate over
+	public static Iterator<Block> getRegionBlockIterator(
+			Iterator<WorldGuardRegion> regionIterator) {
+
+		if (!regionIterator.hasNext()) {
 			return Collections.emptyIterator();
 		}
+
 		return new Iterator<>() {
+
 			Iterator<Block> currentBlockIterator = nextIterator();
 
 			private Iterator<Block> nextIterator() {
-				if (!regionIterator.hasNext()) { // no new blocks, reuse empty iterator
+				if (!regionIterator.hasNext()) {
 					return currentBlockIterator;
 				}
+
 				WorldGuardRegion region = regionIterator.next();
 				World world = region.world();
-				return Iterators.transform(region.asWorldEditRegion().iterator(),
-						blockVector -> world.getBlockAt(blockVector.getX(), blockVector.getY(), blockVector.getZ()));
+
+				return Iterators.transform(
+						region.asWorldEditRegion().iterator(),
+						blockVector -> world.getBlockAt(
+								blockVector.x(),
+								blockVector.y(),
+								blockVector.z()
+						)
+				);
 			}
 
 			@Override
@@ -185,6 +215,7 @@ public final class RegionUtils {
 				if (!currentBlockIterator.hasNext()) {
 					currentBlockIterator = nextIterator();
 				}
+
 				return currentBlockIterator.hasNext();
 			}
 
@@ -193,9 +224,9 @@ public final class RegionUtils {
 				if (!currentBlockIterator.hasNext()) {
 					currentBlockIterator = nextIterator();
 				}
+
 				return currentBlockIterator.next();
 			}
 		};
 	}
-
 }

--- a/src/main/java/org/skriptlang/skriptworldguard/worldguard/WorldGuardFlag.java
+++ b/src/main/java/org/skriptlang/skriptworldguard/worldguard/WorldGuardFlag.java
@@ -106,8 +106,7 @@ public record WorldGuardFlag<F, T>(Flag<T> flag, FlagValueConverter<F, T> valueC
 		mappings.put(VectorFlag.class, Vector3.class);
 		converters.put(Vector3.class, new FlagValueConverter<>(Vector.class, Vector3.class,
 				from -> Vector3.at(from.getX(), from.getY(), from.getZ()),
-				to -> new Vector(to.getX(), to.getY(), to.getZ())));
-
+        to -> new Vector(to.x(), to.y(), to.z())));
 		// Additional mappings
 		// no WorldGuard GameMode -> Bukkit GameMode adapter...
 		converters.put(com.sk89q.worldedit.world.gamemode.GameMode.class,

--- a/src/main/java/org/skriptlang/skriptworldguard/worldguard/WorldGuardRegion.java
+++ b/src/main/java/org/skriptlang/skriptworldguard/worldguard/WorldGuardRegion.java
@@ -73,7 +73,7 @@ public record WorldGuardRegion(World world, ProtectedRegion region) implements C
 		Region worldEditRegion;
 		if (region instanceof ProtectedPolygonalRegion polygonalRegion) { // Not as simple as a cube...
 			worldEditRegion = new Polygonal2DRegion(BukkitAdapter.adapt(world), polygonalRegion.getPoints(),
-					polygonalRegion.getMinimumPoint().getY(), polygonalRegion.getMaximumPoint().getY());
+					polygonalRegion.getMinimumPoint().y(), polygonalRegion.getMaximumPoint().y());
 		} else if (region instanceof ProtectedCuboidRegion) {
 			worldEditRegion = new CuboidRegion(BukkitAdapter.adapt(world),
 					region.getMinimumPoint(), region.getMaximumPoint());

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 main: org.skriptlang.skriptworldguard.SkriptWorldGuard
-api-version: 1.19
+api-version: 26.2
 name: skript-worldguard
 authors: ['SkriptLang Team', Contributors]
 description: Official WorldGuard 7 Addon for Skript

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 main: org.skriptlang.skriptworldguard.SkriptWorldGuard
-api-version: 26.2
+api-version: 1.21
 name: skript-worldguard
 authors: ['SkriptLang Team', Contributors]
 description: Official WorldGuard 7 Addon for Skript


### PR DESCRIPTION





Updated the plugin for supported Minecraft 26.2/Purpur API and fixed the deprecated Java API usages. The changes have been tested successfully with Gradle compilation. Please review when available.

## Testing

This fork has been tested on a live Minecraft server running Purpur 26.2.

### Tested functionality

- `skript-worldguard` loads successfully.
- WorldGuard regions are detected by Skript.
- `on worldguard region enter` works correctly.
- `on worldguard region leave` works correctly.
- A BossBar is displayed when entering/leaving the PvP region.
- Plugin loads without Java compilation/runtime errors related to the updated API.

### Server environment

- Minecraft/Purpur: 26.2
- Skript: [version]
- WorldGuard: 7.0.18
- skript-worldguard: 1.0.2
- Java: 25

### Proof

The attached screenshots show the plugin loaded on the server and its `/plugins` information.

A screen recording is also provided showing the plugin being tested in-game.
https://github.com/user-attachments/assets/e73a319b-bf84-4c1e-9202-98d54b534e52
<img width="2280" height="1080" alt="Screenshot_20260816-200255" src="https://github.com/user-attachments/assets/bd188eab-39a7-489b-816c-10cdaba49737" />
<img width="2280" height="1080" alt="Screenshot_20260816-200233" src="https://github.com/user-attachments/assets/e8f9d2da-30b3-4a44-a47a-3ca47f811870" />
